### PR TITLE
bugfix: updating parsing of terraform registry

### DIFF
--- a/pkg/list_versions.go
+++ b/pkg/list_versions.go
@@ -26,11 +26,11 @@ func GetTFList(mirrorURL string, preRelease bool) ([]string, error) {
 	var semver string
 	if preRelease {
 		// Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
-		semver = `\/(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?\"`
+		semver = `\/(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?\/\"`
 	} else if !preRelease {
 		// Getting versions from body; should return match /X.X.X/ where X is a number
 		// without the ending '"' pre-release folders would be tried and break.
-		semver = `\/(\d+\.\d+\.\d+)\"`
+		semver = `\/(\d+\.\d+\.\d+)\/\"`
 	}
 	r, _ := regexp.Compile(semver)
 	for i := range result {


### PR DESCRIPTION
Updating the parsing of Terraform registry (https://releases.hashicorp.com/terraform) to take care of this error: 
```
ERROR[2022-06-19T18:25:04+03:00]/home/runner/work/simple-tfswitch/simple-tfswitch/pkg/list_versions.go:45 github.com/terraform-tools/simple-tfswitch/pkg.GetTFList() Cannot get list from mirror: https://releases.hashicorp.com/terraform
ERROR[2022-06-19T18:25:04+03:00]/home/runner/work/simple-tfswitch/simple-tfswitch/pkg/install.go:192 github.com/terraform-tools/simple-tfswitch/pkg.installFromConstraint() No version found to match constraint. Follow the README.md instructions for setup. https://github.com/terraform-tools/simple-tfswitch/blob/main/README.md
```

tested locally by creating build and running it on Terraform code of another repository.